### PR TITLE
feat: release v0.0.6 — 121 constants, security hardening, datetime, examples

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -25,8 +25,8 @@ fix or mitigation within **7 days**.
 
 | Version | Supported |
 |:--------|:----------|
-| 0.0.5   | Yes       |
-| < 0.0.5 | No        |
+| 0.0.6   | Yes       |
+| < 0.0.6 | No        |
 
 ## Security Posture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     uses: sebastienrousseau/pipelines/.github/workflows/security.yml@main
     with:
       language: rust
+      severity-threshold: moderate
 
   docs:
     if: github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-04-05
+
+### Added
+
+- 66 new constants (121 total): particle masses (muon, tau, deuteron,
+  triton, helion, alpha), mass ratios, magnetic moments and g-factors,
+  eV equivalents, Compton wavelengths, radiation constants, Josephson
+  and von Klitzing constants, Hartree energy, Planck units (mass,
+  length, time, temperature, charge), molar/thermodynamic constants,
+  electromagnetic constants, atomic unit conversions, W/Z/Higgs boson
+  masses (PDG 2022), particle masses in MeV/c², reduced Compton
+  wavelengths, gas constant in L·atm/(mol·K)
+- `Category` enum on `CONSTANTS_TABLE` for filtering
+  (Mathematical/Physical/Cryptographic)
+- `DateTime::now()`, `from_unix_timestamp()`, `add_seconds()`,
+  `add_hours()`, `add_days()`
+- `impl TryFrom<&str>` and `impl From<SystemTime>` for `DateTime`
+- `impl Display` for `ConstantValue` (all 5 variants)
+- `impl FromIterator<String>` for `Words`
+- 6 example files: constants_math, constants_physical,
+  constants_lookup, datetime_demo, words_demo, macros_demo
+- `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]` on all
+  std-gated items for docs.rs feature badges
+
+### Changed
+
+- `CONSTANTS_TABLE` now includes `Category` metadata (was flat tuples)
+- 8 std-dependent macros gated behind `cfg(feature = "std")`; 7 remain
+  `no_std`-compatible
+- `Common::words()` gracefully handles malformed JSON instead of
+  panicking
+- `Common::parse()` uses `is_some_and()` instead of `.unwrap()`
+- Removed `eprintln` from library code
+- `unsafe_code` lint changed from `"allow"` to `"forbid"` in Cargo.toml
+- Removed conflicting `exclude`/`include` in Cargo.toml
+- Removed unused `commons` git dependency
+- Updated `deny.toml` for cargo-deny 0.19 schema
+- Rewrote SECURITY.md with contact, versions table, security posture
+
+### Fixed
+
+- CI: removed invalid `coverage-threshold` input (startup_failure)
+- CI: applied `cargo fmt` for max_width = 72
+- CI: added `#![allow(missing_docs)]` to test crates
+- CI: bumped `actions/checkout` from v4 to v6
+- CI: fixed `severity-threshold` from `medium` to `moderate`
+- CI: added `main` to GitHub Pages deployment branch policy
+
 ## [0.0.5] - 2026-04-05
 
 ### Added
@@ -84,5 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Constants` struct with `constant()` and `constants()` methods
 - Basic macro set (`cmn!`, `cmn_parse!`)
 
+[0.0.6]: https://github.com/sebastienrousseau/cmn/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/sebastienrousseau/cmn/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/sebastienrousseau/cmn/releases/tag/v0.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ cargo build
 cargo test
 ```
 
-All 198+ tests should pass. If they don't, open an issue before proceeding.
+All 295+ tests should pass. If they don't, open an issue before proceeding.
 
 ## Signed Commits (Required)
 
@@ -67,7 +67,7 @@ git log --show-signature -1
 | Feature | `feat/<description>` | `feat/add-ln2-constant` |
 | Fix | `fix/<description>` | `fix/phi-precision` |
 | Docs | `docs/<description>` | `docs/update-readme` |
-| Release | `feat/vX.Y.Z` | `feat/v0.0.5` |
+| Release | `feat/vX.Y.Z` | `feat/v0.0.6` |
 
 ## Commit Messages
 
@@ -87,7 +87,7 @@ Before opening a PR, verify:
 
 - [ ] `cargo fmt --check` passes
 - [ ] `cargo clippy --all-targets` has zero warnings
-- [ ] `cargo test` passes (all 198+ tests)
+- [ ] `cargo test` passes (all 295+ tests)
 - [ ] `cargo doc` builds without warnings
 - [ ] New public API items have `///` doc comments
 - [ ] All commits are signed (`git log --show-signature`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmn"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "assert_cmd",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = [
     "cryptography",
     "development-tools",
 ]
-description = "55 mathematical, physical, and cryptographic constants for Rust — no_std, WASM-ready, compile-time const, typed runtime lookup, 14 utility macros"
+description = "121 mathematical, physical, and cryptographic constants for Rust — no_std, WASM-ready, compile-time const, typed runtime lookup, 14 utility macros"
 documentation = "https://docs.rs/cmn"
 edition = "2021"
 homepage = "https://cmnlib.com/"
@@ -32,7 +32,7 @@ name = "cmn"
 readme = "README.md"
 repository = "https://github.com/sebastienrousseau/cmn/"
 rust-version = "1.72"
-version = "0.0.5"
+version = "0.0.6"
 
 [[bench]]
 name = "benchmark"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Common (CMN)</h1>
 
 <p align="center">
-  <strong>55 mathematical and cryptographic constants for Rust. Zero runtime cost. One dependency.</strong>
+  <strong>121 mathematical and cryptographic constants for Rust. Zero runtime cost. One dependency.</strong>
 </p>
 
 <p align="center">
@@ -13,7 +13,7 @@
   <a href="https://crates.io/crates/cmn"><img src="https://img.shields.io/crates/v/cmn.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/cmn"><img src="https://img.shields.io/badge/docs.rs-cmn-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/cmn"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/cmn?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/cmn"><img src="https://img.shields.io/badge/lib.rs-v0.0.5-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/cmn"><img src="https://img.shields.io/badge/lib.rs-v0.0.6-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -22,7 +22,7 @@
 
 CMN gives you accurate, well-documented mathematical and physical constants as compile-time `const` values in Rust. Every constant resolves at compile time with zero runtime allocation.
 
-**One line to install. Zero configuration. 198 tests. 100% code coverage.**
+**One line to install. Zero configuration. 295 tests. 100% code coverage.**
 
 ```bash
 cargo add cmn
@@ -44,12 +44,12 @@ cargo add cmn
 
 | | `cmn` | `physical_constants` | `natural_constants` | `std::f64::consts` |
 |:---|:---:|:---:|:---:|:---:|
-| **Constants** | 55 | 354 | 370+ | 11 |
+| **Constants** | 121 | 354 | 370+ | 11 |
 | **Runtime typed lookup** | `ConstantValue` enum | -- | -- | -- |
 | **Utility macros** | 14 | -- | -- | -- |
 | **Word list** | Built-in | -- | -- | -- |
 | **License** | MIT / Apache-2.0 | GPL-3.0 | MIT | stdlib |
-| **Test coverage** | 100% (198 tests) | Unknown | Unknown | N/A |
+| **Test coverage** | 100% (295 tests) | Unknown | Unknown | N/A |
 | **Documentation** | 100% | 100% | 29% | stdlib |
 | **MSRV** | 1.72 | Unspecified | Unspecified | N/A |
 
@@ -63,7 +63,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-cmn = "0.0.5"
+cmn = "0.0.6"
 ```
 
 Requires [Rust](https://rustup.rs/) 1.72+. Works on macOS, Linux, and Windows.
@@ -232,7 +232,7 @@ Full API reference: [docs.rs/cmn](https://docs.rs/cmn)
 ```mermaid
 graph LR
     subgraph "cmn crate"
-        B["constants.rs<br/>55 const values<br/>Constants lookup API"]
+        B["constants.rs<br/>121 const values<br/>Constants lookup API"]
         C["words.rs<br/>Words HashSet<br/>WORD_LIST dictionary"]
         D["macros.rs<br/>14 utility macros"]
         A["lib.rs<br/>Common struct<br/>JSON serde bridge"]
@@ -250,7 +250,7 @@ graph LR
 
 | Module | What it does | When to use it |
 |:---|:---|:---|
-| [`constants`](https://docs.rs/cmn/latest/cmn/constants/) | 55 compile-time `const` values + `Constants` runtime API + `ConstantValue` enum | You need a mathematical or physical constant |
+| [`constants`](https://docs.rs/cmn/latest/cmn/constants/) | 121 compile-time `const` values + `Constants` runtime API + `ConstantValue` enum | You need a mathematical or physical constant |
 | [`words`](https://docs.rs/cmn/latest/cmn/words/) | `Words` struct backed by `HashSet<String>` with add/remove/contains + `WORD_LIST` | Passphrase generation, word games, text processing |
 | [`macros`](https://docs.rs/cmn/latest/cmn/macros/) | 14 macros: `cmn_max!`, `cmn_min!`, `cmn_vec!`, `cmn_map!`, `cmn_in_range!`, etc. | Quick utilities without writing boilerplate |
 | [`datetime`](https://docs.rs/cmn/latest/cmn/datetime/) | ISO 8601 parsing, relative formatting, duration math, timezone offsets | Timestamps, "3 hours ago", duration calculations — no external crate |
@@ -261,12 +261,12 @@ graph LR
 ## FAQ
 
 **How accurate are the constants?**
-Mathematical constants use `std::f64::consts` where available (PI, E, TAU, SQRT2). Physical constants are sourced from CODATA 2018 recommended values. All values are validated by 198 tests including mathematical identity checks (e.g., `SQRT2^2 == 2`, `R == k_B * N_A`).
+Mathematical constants use `std::f64::consts` where available (PI, E, TAU, SQRT2). Physical constants are sourced from CODATA 2018 recommended values. All values are validated by 295 tests including mathematical identity checks (e.g., `SQRT2^2 == 2`, `R == k_B * N_A`).
 
 **Does CMN support `no_std`?**
-Yes. Disable default features to get all 55 `const` values and 14 macros with zero dependencies:
+Yes. Disable default features to get all 121 `const` values and 14 macros with zero dependencies:
 ```toml
-cmn = { version = "0.0.5", default-features = false }
+cmn = { version = "0.0.6", default-features = false }
 ```
 The `Constants` runtime API, `Words`, and `Common` structs require the `std` feature (enabled by default).
 
@@ -297,7 +297,7 @@ Rust **1.72**. Tested on stable. No nightly features required.
 git clone https://github.com/sebastienrousseau/cmn.git
 cd cmn
 cargo build        # Compile
-cargo test         # 198 tests, 100% coverage
+cargo test         # 295 tests, 100% coverage
 cargo clippy       # Zero warnings
 cargo fmt --check  # Verify formatting
 cargo doc --open   # Browse API docs locally

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -65,7 +65,7 @@ array of characters.
 [crates-badge]: https://img.shields.io/crates/v/cmn.svg?style=for-the-badge 'Crates.io badge'
 [divider]: https://kura.pro/common/images/elements/divider.svg "divider"
 [docs-badge]: https://img.shields.io/docsrs/cmn.svg?style=for-the-badge 'Docs.rs badge'
-[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.5-orange.svg?style=for-the-badge 'Lib.rs badge'
+[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.6-orange.svg?style=for-the-badge 'Lib.rs badge'
 [license-badge]: https://img.shields.io/crates/l/cmn.svg?style=for-the-badge 'License badge'
 [made-with-rust-badge]: https://img.shields.io/badge/rust-f04041?style=for-the-badge&labelColor=c0282d&logo=rust 'Made With Rust badge'
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -27,7 +27,7 @@ pub struct Constant {
     pub value: String,
 }
 
-/// Collection of 110 mathematical, physical, and cryptographic constants.
+/// Collection of 121 mathematical, physical, and cryptographic constants.
 /// Requires the `std` feature.
 #[cfg(feature = "std")]
 #[derive(Clone, Serialize, Debug)]
@@ -119,7 +119,7 @@ impl Constants {
             .cloned()
     }
 
-    /// Returns a slice of all 110 constants.
+    /// Returns a slice of all 121 constants.
     ///
     /// # Example
     ///
@@ -127,7 +127,7 @@ impl Constants {
     /// use cmn::constants::Constants;
     ///
     /// let constants = Constants::new();
-    /// assert_eq!(constants.constants().len(), 110);
+    /// assert_eq!(constants.constants().len(), 121);
     /// ```
     pub fn constants(&self) -> &[Constant] {
         &self.constants
@@ -141,12 +141,12 @@ impl Constants {
     /// use cmn::constants::Constants;
     ///
     /// let constants = Constants::new();
-    /// assert_eq!(constants.constants().len(), 110);
+    /// assert_eq!(constants.constants().len(), 121);
     ///
     /// ```
     ///
     pub fn new() -> Self {
-        let mut constants = Vec::with_capacity(110);
+        let mut constants = Vec::with_capacity(121);
         constants.extend([
             Constant {
                 name: "APERY",
@@ -599,6 +599,53 @@ impl Constants {
                 name: "ATOMIC_UNIT_OF_POLARIZABILITY",
                 value: ATOMIC_UNIT_OF_POLARIZABILITY.to_string(),
             },
+            // --- Boson masses & MeV forms ---
+            Constant {
+                name: "W_BOSON_MASS_GEV",
+                value: W_BOSON_MASS_GEV.to_string(),
+            },
+            Constant {
+                name: "Z_BOSON_MASS_GEV",
+                value: Z_BOSON_MASS_GEV.to_string(),
+            },
+            Constant {
+                name: "HIGGS_BOSON_MASS_GEV",
+                value: HIGGS_BOSON_MASS_GEV.to_string(),
+            },
+            Constant {
+                name: "ELECTRON_MASS_MEV",
+                value: ELECTRON_MASS_MEV.to_string(),
+            },
+            Constant {
+                name: "PROTON_MASS_MEV",
+                value: PROTON_MASS_MEV.to_string(),
+            },
+            Constant {
+                name: "NEUTRON_MASS_MEV",
+                value: NEUTRON_MASS_MEV.to_string(),
+            },
+            Constant {
+                name: "MUON_MASS_MEV",
+                value: MUON_MASS_MEV.to_string(),
+            },
+            // --- Reduced Compton wavelengths ---
+            Constant {
+                name: "ELECTRON_REDUCED_COMPTON",
+                value: ELECTRON_REDUCED_COMPTON.to_string(),
+            },
+            Constant {
+                name: "PROTON_REDUCED_COMPTON",
+                value: PROTON_REDUCED_COMPTON.to_string(),
+            },
+            Constant {
+                name: "NEUTRON_REDUCED_COMPTON",
+                value: NEUTRON_REDUCED_COMPTON.to_string(),
+            },
+            // --- Gas constant variant ---
+            Constant {
+                name: "GAS_CONSTANT_L_ATM",
+                value: GAS_CONSTANT_L_ATM.to_string(),
+            },
         ]);
 
         Self { constants }
@@ -814,6 +861,17 @@ pub const CONSTANTS_TABLE: &[(&str, f64, Category)] = &[
         ATOMIC_UNIT_OF_POLARIZABILITY,
         P,
     ),
+    ("W_BOSON_MASS_GEV", W_BOSON_MASS_GEV, P),
+    ("Z_BOSON_MASS_GEV", Z_BOSON_MASS_GEV, P),
+    ("HIGGS_BOSON_MASS_GEV", HIGGS_BOSON_MASS_GEV, P),
+    ("ELECTRON_MASS_MEV", ELECTRON_MASS_MEV, P),
+    ("PROTON_MASS_MEV", PROTON_MASS_MEV, P),
+    ("NEUTRON_MASS_MEV", NEUTRON_MASS_MEV, P),
+    ("MUON_MASS_MEV", MUON_MASS_MEV, P),
+    ("ELECTRON_REDUCED_COMPTON", ELECTRON_REDUCED_COMPTON, P),
+    ("PROTON_REDUCED_COMPTON", PROTON_REDUCED_COMPTON, P),
+    ("NEUTRON_REDUCED_COMPTON", NEUTRON_REDUCED_COMPTON, P),
+    ("GAS_CONSTANT_L_ATM", GAS_CONSTANT_L_ATM, P),
 ];
 
 /// Apéry's constant, which is the sum of the reciprocals of the positive cubes.
@@ -1109,7 +1167,7 @@ pub const ELECTRON_PROTON_MASS_RATIO: f64 = 5.446_170_214_87e-4;
 
 /// Proton-to-electron mass ratio (CODATA 2018).
 /// m_p / m_e ≈ 1836.15267343
-pub const PROTON_ELECTRON_MASS_RATIO: f64 = 1836.152_673_43;
+pub const PROTON_ELECTRON_MASS_RATIO: f64 = 1_836.152_673_43;
 
 /// Muon-to-electron mass ratio (CODATA 2018).
 /// m_μ / m_e ≈ 206.7682830
@@ -1326,3 +1384,59 @@ pub const ATOMIC_UNIT_OF_ELECTRIC_FIELD: f64 = 5.142_206_747_63e11;
 /// Atomic unit of electric polarizability.
 /// e²a₀²/E_h ≈ 1.64877727436e-41 C²m²/J
 pub const ATOMIC_UNIT_OF_POLARIZABILITY: f64 = 1.648_777_274_36e-41;
+
+// ---------------------------------------------------------------
+// Particle masses in MeV/c² and boson masses
+// ---------------------------------------------------------------
+
+/// W boson mass (PDG 2022).
+/// m_W ≈ 80.377 GeV/c²
+pub const W_BOSON_MASS_GEV: f64 = 80.377;
+
+/// Z boson mass (PDG 2022).
+/// m_Z ≈ 91.1876 GeV/c²
+pub const Z_BOSON_MASS_GEV: f64 = 91.1876;
+
+/// Higgs boson mass (PDG 2022).
+/// m_H ≈ 125.25 GeV/c²
+pub const HIGGS_BOSON_MASS_GEV: f64 = 125.25;
+
+/// Electron mass in MeV/c² (CODATA 2018).
+/// m_e c² ≈ 0.51099895000 MeV
+pub const ELECTRON_MASS_MEV: f64 = 0.510_998_950_00;
+
+/// Proton mass in MeV/c² (CODATA 2018).
+/// m_p c² ≈ 938.27208816 MeV
+pub const PROTON_MASS_MEV: f64 = 938.272_088_16;
+
+/// Neutron mass in MeV/c² (CODATA 2018).
+/// m_n c² ≈ 939.56542052 MeV
+pub const NEUTRON_MASS_MEV: f64 = 939.565_420_52;
+
+/// Muon mass in MeV/c² (CODATA 2018).
+/// m_μ c² ≈ 105.6583755 MeV
+pub const MUON_MASS_MEV: f64 = 105.658_375_5;
+
+// ---------------------------------------------------------------
+// Reduced Compton wavelengths (λ̄ = ℏ/(mc))
+// ---------------------------------------------------------------
+
+/// Reduced Compton wavelength of the electron.
+/// λ̄_e = ℏ/(m_e c) ≈ 3.8615926796e-13 m
+pub const ELECTRON_REDUCED_COMPTON: f64 = 3.861_592_679_6e-13;
+
+/// Reduced Compton wavelength of the proton.
+/// λ̄_p = ℏ/(m_p c) ≈ 2.10308910336e-16 m
+pub const PROTON_REDUCED_COMPTON: f64 = 2.103_089_103_36e-16;
+
+/// Reduced Compton wavelength of the neutron.
+/// λ̄_n = ℏ/(m_n c) ≈ 2.10019415600e-16 m
+pub const NEUTRON_REDUCED_COMPTON: f64 = 2.100_194_156_00e-16;
+
+// ---------------------------------------------------------------
+// Molar gas constant in other units
+// ---------------------------------------------------------------
+
+/// Molar gas constant in L·atm/(mol·K).
+/// R ≈ 0.08205736608 L·atm/(mol·K)
+pub const GAS_CONSTANT_L_ATM: f64 = 0.082_057_366_08;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 //! # Common (CMN)
 //!
-//! 110 mathematical and cryptographic constants for Rust.
+//! 121 mathematical and cryptographic constants for Rust.
 //! Zero runtime cost. `no_std` compatible.
 //!
 //! ## Why CMN?
@@ -19,7 +19,7 @@
 //!
 //! ## Modules
 //!
-//! - **[`constants`]** — 110 `const` values (PI, Avogadro,
+//! - **[`constants`]** — 121 `const` values (PI, Avogadro,
 //!   Planck, etc.). With `std`: runtime `Constants` lookup API
 //!   + `ConstantValue` typed enum.
 //! - **[`macros`]** — 14 utility macros for min/max,
@@ -85,7 +85,7 @@ use serde::{Deserialize, Serialize};
 /// and string operations. Available in `no_std`.
 pub mod macros;
 
-/// 110 mathematical, physical, and cryptographic constants as
+/// 121 mathematical, physical, and cryptographic constants as
 /// compile-time `const` values. The `const` values are always
 /// available, even in `no_std`. The runtime `Constants` lookup
 /// API and `ConstantValue` enum require the `std` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! For `no_std`, disable default features:
 //! ```toml
 //! [dependencies]
-//! cmn = { version = "0.0.5", default-features = false }
+//! cmn = { version = "0.0.6", default-features = false }
 //! ```
 //!
 //! ## License

--- a/tests/test_constants.rs
+++ b/tests/test_constants.rs
@@ -32,7 +32,7 @@ mod tests {
     #[test]
     fn new_creates_55_constants() {
         let c = Constants::new();
-        assert_eq!(c.constants().len(), 110);
+        assert_eq!(c.constants().len(), 121);
     }
 
     #[test]
@@ -642,9 +642,9 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn constants_table_has_106_float_entries() {
+    fn constants_table_has_117_float_entries() {
         use cmn::constants::CONSTANTS_TABLE;
-        assert_eq!(CONSTANTS_TABLE.len(), 106);
+        assert_eq!(CONSTANTS_TABLE.len(), 117);
     }
 
     #[test]

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -15,7 +15,7 @@ mod tests {
         let common = Common::new();
         // constants() delegates to Constants::default, so it should work
         let constants = common.constants();
-        assert_eq!(constants.constants().len(), 110);
+        assert_eq!(constants.constants().len(), 121);
     }
 
     #[test]
@@ -37,7 +37,7 @@ mod tests {
     fn constants_returns_default_constants_instance() {
         let common = Common::default();
         let constants = common.constants();
-        assert_eq!(constants.constants().len(), 110);
+        assert_eq!(constants.constants().len(), 121);
         assert_eq!(
             constants.constants(),
             Constants::default().constants()

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -252,7 +252,7 @@ mod regression {
             v["constants"].is_array(),
             "'constants' must serialise as an array"
         );
-        assert_eq!(v["constants"].as_array().unwrap().len(), 110);
+        assert_eq!(v["constants"].as_array().unwrap().len(), 121);
     }
 
     /// Common serialise → deserialise must be idempotent.
@@ -328,7 +328,7 @@ mod regression {
             .map(|_| {
                 let c = Arc::clone(&c);
                 std::thread::spawn(move || {
-                    assert_eq!(c.constants().len(), 110);
+                    assert_eq!(c.constants().len(), 121);
                     let _ = c.constant("PI");
                     let _ = c.get_value("EULER");
                 })
@@ -390,7 +390,7 @@ mod regression {
             })
             .collect();
         for h in handles {
-            assert_eq!(h.join().unwrap(), 110);
+            assert_eq!(h.join().unwrap(), 121);
         }
     }
 
@@ -609,13 +609,13 @@ mod regression {
     //    change across releases.
     // ===============================================================
 
-    /// The library must expose exactly 110 constants.
+    /// The library must expose exactly 121 constants.
     #[test]
-    fn reg_45_exactly_110_constants() {
+    fn reg_45_exactly_121_constants() {
         assert_eq!(
             Constants::new().constants().len(),
-            110,
-            "Public API contract: 110 constants"
+            121,
+            "Public API contract: 121 constants"
         );
     }
 


### PR DESCRIPTION
## Summary

Major expansion release: 121 constants (up from 55), security hardening, `no_std` macro correctness, new `datetime` functionality, 6 example files, and CI fixes. All changes since v0.0.5 (`dab18c5`).

### Constants — 121 total (was 55 in v0.0.5)

**+66 new constants across 11 categories:**

- **Particle masses (6):** muon, tau, deuteron, triton, helion, alpha particle
- **Mass ratios (5):** e/p, p/e, mu/e, n/p, d/p
- **Magnetic moments & g-factors (7):** Bohr/nuclear magnetons, electron/proton/neutron magnetic moments, electron/proton g-factors
- **eV equivalents (6):** eV to kg, AMU, Hz, kelvin, inverse meter + ELECTRON_VOLT
- **Atomic & nuclear (11):** classical electron radius, Compton wavelengths (e/p/n), Thomson cross section, radiation constants (1st/2nd), Josephson, von Klitzing, Hartree energy (J + eV)
- **Planck units (5):** mass, length, time, temperature, charge
- **Molar & thermodynamic (5):** molar mass constant, molar Planck constant, Loschmidt, molar volume, Sackur-Tetrode
- **Electromagnetic (4):** impedance of free space, inverse fine-structure, electron/proton charge-to-mass
- **Atomic units (6):** length, time, velocity, force, electric field, polarizability
- **Boson masses — PDG 2022 (3):** W (80.377 GeV), Z (91.1876 GeV), Higgs (125.25 GeV)
- **MeV/c² forms (4):** electron, proton, neutron, muon mass in MeV
- **Reduced Compton wavelengths (3):** electron, proton, neutron ℏ/(mc)
- **Gas constant variant (1):** GAS_CONSTANT_L_ATM in L·atm/(mol·K)

`CONSTANTS_TABLE`: 117 entries with `Category` enum (Mathematical/Physical). `Constants` API: 121 entries.

### Security Hardening

- **S1-S2:** Replaced `.expect()`/`.unwrap()` in `Common::words()` with graceful `filter_map` — malformed JSON no longer panics
- **S3:** Replaced fragile `.as_object().unwrap()` with `.is_some_and()` in `Common::parse()`
- **S4:** Removed `eprintln` from library code
- **S5:** Changed `unsafe_code = "allow"` to `"forbid"` in Cargo.toml lints
- **S6:** Rewrote SECURITY.md with contact email, GitHub Advisories link, supported versions table

### Code Quality

- Gated 8 std-dependent macros behind `cfg(feature = "std")`; 7 remain `no_std`-compatible
- Removed dead commented-out code block in macros.rs
- Removed conflicting `exclude`/`include` in Cargo.toml (Cargo ignores `exclude` when `include` is present)
- Fixed `deny.toml` for cargo-deny 0.19 schema
- Removed unused `commons` git dependency (blocked `cargo publish`)

### New Functionality

- **`DateTime::now()`** — current UTC time from system clock
- **`DateTime::from_unix_timestamp()`** — construct from epoch
- **`DateTime::add_seconds/add_hours/add_days`** — arithmetic
- **`impl TryFrom<&str> for DateTime`** — idiomatic parsing
- **`impl From<SystemTime> for DateTime`** — system clock conversion
- **`impl Display for ConstantValue`** — all 5 variants printable
- **`impl FromIterator<String> for Words`** — standard trait
- **`Category` enum** on `CONSTANTS_TABLE` for filtering (Mathematical/Physical/Cryptographic)

### Examples (6 new files)

| Example | What it demonstrates |
|:---|:---|
| `constants_math.rs` | All mathematical constants + identity checks (PHI²=PHI+1, e^ln2=2) |
| `constants_physical.rs` | All physical constants + relationship proofs (R=k_B*N_A, F=N_A*e) |
| `constants_lookup.rs` | Runtime typed lookup, `Display`, `CONSTANTS_TABLE`, `Category` filtering |
| `datetime_demo.rs` | Full datetime API: parse, now, arithmetic, duration, relative, TryFrom, From |
| `words_demo.rs` | Full words API: default, add/remove, FromIterator, serde roundtrip |
| `macros_demo.rs` | All 15 macros: no_std (7) + std (8) |

### Documentation

- `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]` on all std-gated items
- docs.rs metadata: `all-features = true`, `--cfg docsrs`
- SECURITY.md rewritten with contact, versions, posture

### CI Fixes

- Removed invalid `coverage-threshold` input (caused `startup_failure`)
- Applied `cargo fmt` (max_width = 72)
- Added `#![allow(missing_docs)]` to test crates (clippy `-D warnings`)
- Bumped `actions/checkout` from v4 to v6
- Added `main` to GitHub Pages deployment branch policy

## Verification

```
cargo test                              295 passed, 0 failed
cargo clippy --all-features -D warnings 0 errors, 0 warnings
cargo doc --no-deps                     0 warnings
cargo tarpaulin                         100.00% (696/696 lines)
cargo check --no-default-features       clean (no_std)
cargo build --target wasm32             clean (WASM)
cargo audit                             0 vulnerabilities
cargo deny check                        advisories ok, bans ok, licenses ok, sources ok
```

## Test plan

- [x] `cargo test` — 295 tests pass
- [x] `cargo clippy --all-features -D warnings` — zero warnings
- [x] `cargo doc --no-deps` — zero warnings
- [x] `cargo tarpaulin` — 100% coverage (696/696)
- [x] `cargo check --no-default-features` — no_std compiles
- [x] `cargo build --target wasm32-unknown-unknown` — WASM compiles
- [x] `cargo audit` — 0 vulnerabilities
- [x] `cargo deny check` — all clean
- [x] All 7 examples run without error
- [ ] CI pipeline passes on GitHub Actions